### PR TITLE
Support balances of more than 1000, reduce number of API requests

### DIFF
--- a/IOTA.lua
+++ b/IOTA.lua
@@ -1,5 +1,5 @@
 -- Inofficial IOTA Extension for MoneyMoney
--- Fetches IOTA quantity for addresses via IOTASear.ch
+-- Fetches IOTA quantity for addresses via nodes.iota.cafe
 -- Fetches IOTA price in EUR via coinmarketcap API
 -- Returns cryptoassets as securities
 --
@@ -8,7 +8,7 @@
 
 -- MIT License
 
--- Copyright (c) 2017 PSperber
+-- Copyright (c) 2018 PSperber, aaronk6
 
 -- Permission is hereby granted, free of charge, to any person obtaining a copy
 -- of this software and associated documentation files (the "Software"), to deal
@@ -35,16 +35,16 @@ WebBanking {
     services = { "IOTA" }
 }
 
-local iotaAddress
+local iotaAddresses
 local connection = Connection()
-local currency = "EUR" -- fixme: make dynamik if MM enables input field
+local currency = "EUR" -- fixme: make dynamic if MM enables input field
 
 function SupportsBank(protocol, bankCode)
     return protocol == ProtocolWebBanking and bankCode == "IOTA"
 end
 
 function InitializeSession(protocol, bankCode, username, username2, password, username3)
-    iotaAddress = username:gsub("%s+", "")
+    iotaAddresses = username
 end
 
 function ListAccounts(knownAccounts)
@@ -61,16 +61,16 @@ end
 
 function RefreshAccount(account, since)
     local s = {}
-    prices = requestIOTAPrice()
+    local prices = requestIOTAPrice()
+    local addresses = strsplit(",%s*", iotaAddresses)
+    local balances = requestIOTAQuantitiesForIOTAAddresses(addresses)
 
-    for address in string.gmatch(iotaAddress, '([^,]+)') do
-        iotaQuantity = requestIOTAQuantityForIOTAAddress(address)
-
-        s[#s + 1] = {
-            name = address,
+    for i,v in ipairs(addresses) do
+        s[i] = {
+            name = v,
             currency = nil,
             market = "cryptocompare",
-            quantity = iotaQuantity,
+            quantity = balances[i] / 1000000, -- convert to MIOTA
             price = prices["price_eur"],
         }
     end
@@ -82,7 +82,7 @@ function EndSession()
 end
 
 
--- Querry Functions
+-- Query Functions
 function requestIOTAPrice()
     response = connection:request("GET", cryptocompareRequestUrl(), {})
     json = JSON(response)
@@ -91,14 +91,23 @@ function requestIOTAPrice()
 end
 
 --
-function requestIOTAQuantityForIOTAAddress(iotaAddress)
-    response = connection:request("GET", iotaRequestUrl(iotaAddress), {})
-    html = HTML(response)
-    elements = html:xpath("//div[@class='summary-info']/div[3]/span[2]")
-    value = elements:get(1):text()
-    for s in string.gmatch(value, '%S+') do
-        return s
+function requestIOTAQuantitiesForIOTAAddresses(iotaAddresses)
+
+    local iotaAddressesWithoutChecksum = {}
+
+    -- strip checksums and add quotes
+    for i,v in ipairs(iotaAddresses) do
+        iotaAddressesWithoutChecksum[i] = '"' .. string.sub(v, 0, 81) .. '"'
     end
+
+    local headers = {}
+    headers["X-IOTA-API-Version"] = "1"
+
+    local postContent = '{"command":"getBalances","addresses":['.. strjoin(',', iotaAddressesWithoutChecksum) ..'],"threshold":100}'
+    content = connection:request("POST", iotaRequestUrl(), postContent, "application/json", headers)
+
+    json = JSON(content)
+    return json:dictionary()["balances"]
 end
 
 
@@ -107,7 +116,39 @@ function cryptocompareRequestUrl()
     return "https://api.coinmarketcap.com/v1/ticker/iota/?convert=EUR"
 end
 
-function iotaRequestUrl(iotaAddress)
-    return "https://iotasear.ch/address/" .. iotaAddress
+function iotaRequestUrl()
+    return "https://nodes.iota.cafe/"
 end
 
+-- from http://lua-users.org/wiki/SplitJoin
+function strjoin(delimiter, list)
+   local len = #list
+   if len == 0 then
+      return ""
+   end
+   local string = list[1]
+   for i = 2, len do
+      string = string .. delimiter .. list[i]
+   end
+   return string
+end
+
+-- from http://lua-users.org/wiki/SplitJoin
+function strsplit(delimiter, text)
+    local list = {}
+    local pos = 1
+    if string.find("", delimiter, 1) then -- this would result in endless loops
+        error("delimiter matches empty string!")
+    end
+    while 1 do
+        local first, last = string.find(text, delimiter, pos)
+        if first then -- found?
+            table.insert(list, string.sub(text, pos, first-1))
+            pos = last+1
+        else
+            table.insert(list, string.sub(text, pos))
+            break
+        end
+   end
+   return list
+end

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # IOTA-MoneyMoney
-Fetches amount and value of privately held IOTA address via IOTASear.ch and returns it as a security.
+Fetches amount and value of privately held IOTA address via https://nodes.iota.cafe/ and returns it as a security.
 This can be also be used to track your cold storage.
 
 Do you like this extension? Donation IOTA address: `OUDFKXFDRSWBCTRSJ9MMFGVENOFGHCADQTJUIKTZJPLPGHEQBCLCZPIANOZ9NO9XQVRRHJNOIJNJTPJRWJBWJXHGFW`
@@ -15,15 +15,22 @@ You can get a signed version of this extension from
 
 Once downloaded, move `IOTA.lua` to your MoneyMoney Extensions folder.
 
-**Note:** This extension requires MoneyMoney **Version 2.3.4** or newer.
-
 ## MoneyMoney Setup
 
 Add a new account (type "IOTA"). 
 
-**Use your IOTA adresses coma seperated as user name**  
-`1KuWLoZuoJgz3N6sLoPwGth9XGm8YuFTGt, 1KuWLoZuoJgz3N6sLoPwGth9XGm8YuFTGt` (example)
+**Use your IOTA adresses coma seperated as user name**
+
+```
+BLNGFQXMLCZ9VSENI9IVZZMYUHZLUBKHEVYARVHZIKYTTGGFUFNMLZDXJPMQVNHWGM9CQNIWATMLVQSFQ, LLWMD9SFZFOVVXJQDGFHCTGQFWEAJOJSNDCCPHTKULJTBMGNO9WZYIMZFTAOODFBKABVRYIJXK9ZP9F9U
+```
+
+(example)
 
 **Use whatever you want as password**  
-`123` (example)
 
+```
+123
+```
+
+(example)


### PR DESCRIPTION
- Fixed: Extension returned wrong value when balance was larger than 1000 MIOTAs (IOTASear.ch displayed Gi then, which broke web-scraping)
- Use IOTA API via nodes.iota.cafe (returns JSON, no scraping necessary)
- Fetch all balances in a single API request
- Fixed some types and renamed a few variables