### PR TITLE
Replaced node URL

### DIFF
--- a/IOTA.lua
+++ b/IOTA.lua
@@ -117,7 +117,7 @@ function cryptocompareRequestUrl()
 end
 
 function iotaRequestUrl()
-    return "https://nodes.iota.cafe/"
+    return "https://iotanode.host/node"
 end
 
 -- from http://lua-users.org/wiki/SplitJoin


### PR DESCRIPTION
https://nodes.iota.cafe/ has stopped working, I therefore replaced it with https://iotanode.host/node.

Longerterm, we should probably have a list of nodes in the extension, so we can fall back to a different node if one of them stops working.