### PR TITLE
Use CoinGecko instead of CoinMarketCap

### DIFF
--- a/IOTA.lua
+++ b/IOTA.lua
@@ -1,6 +1,6 @@
 -- Inofficial IOTA Extension for MoneyMoney
--- Fetches IOTA quantity for addresses via nodes.iota.cafe
--- Fetches IOTA price in EUR via coinmarketcap API
+-- Fetches IOTA quantity for addresses via nodes.thetangle.org
+-- Fetches IOTA price in EUR via CoinGecko API
 -- Returns cryptoassets as securities
 --
 -- Username: IOTA Adresses comma seperated
@@ -61,7 +61,7 @@ end
 
 function RefreshAccount(account, since)
     local s = {}
-    local prices = requestIOTAPrice()
+    local price = requestIOTAPrice()
     local addresses = strsplit(",%s*", iotaAddresses)
     local balances = requestIOTAQuantitiesForIOTAAddresses(addresses)
 
@@ -71,7 +71,7 @@ function RefreshAccount(account, since)
             currency = nil,
             market = "cryptocompare",
             quantity = balances[i] / 1000000, -- convert to MIOTA
-            price = prices["price_eur"],
+            price = price,
         }
     end
 
@@ -87,7 +87,7 @@ function requestIOTAPrice()
     response = connection:request("GET", cryptocompareRequestUrl(), {})
     json = JSON(response)
 
-    return json:dictionary()[1]
+    return json:dictionary()["iota"]["eur"]
 end
 
 --
@@ -115,7 +115,7 @@ end
 
 -- Helper Functions
 function cryptocompareRequestUrl()
-    return "https://api.coinmarketcap.com/v1/ticker/iota/?convert=EUR"
+    return "https://api.coingecko.com/api/v3/simple/price?ids=iota&vs_currencies=eur"
 end
 
 function iotaRequestUrl()

--- a/IOTA.lua
+++ b/IOTA.lua
@@ -8,7 +8,7 @@
 
 -- MIT License
 
--- Copyright (c) 2018 PSperber, aaronk6
+-- Copyright (c) 2020 PSperber, aaronk6
 
 -- Permission is hereby granted, free of charge, to any person obtaining a copy
 -- of this software and associated documentation files (the "Software"), to deal
@@ -30,7 +30,7 @@
 
 
 WebBanking {
-    version = 0.2,
+    version = 0.3,
     description = "Include your IOTAs as cryptoportfolio in MoneyMoney by providing IOTA addresses as usernme (comma seperated) and a random Password",
     services = { "IOTA" }
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Jacubeit
+Copyright (c) 2020 PSperber, aaronk6
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The free, public CoinMarketCap was discontinued. This pull request migrates to CoinGecko API.